### PR TITLE
[RFC]Codec refactor

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -116,6 +116,8 @@ public:
   unsigned int codec_fourcc; // if available
   int profile; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
   int level;   // encoder level of the stream reported by the decoder. used to qualify hw decoders.
+  std::string codec_name;
+  std::string profile_name;
   StreamType type;
   int source;
   bool realtime;
@@ -204,6 +206,7 @@ public:
   int iBitRate;
   int iBitsPerSample;
   uint64_t iChannelLayout;
+  std::string m_channelLayout;
 };
 
 class CDemuxStreamSubtitle : public CDemuxStream

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1144,6 +1144,9 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
         st->iBitRate = pStream->codec->bit_rate;
         st->iBitsPerSample = pStream->codec->bits_per_raw_sample;
         st->iChannelLayout = pStream->codec->channel_layout;
+        char buf[32] = { 0 };
+        av_get_channel_layout_string(buf, 31, st->iChannels, st->iChannelLayout);
+        st->m_channelLayout = buf;
         if (st->iBitsPerSample == 0)
           st->iBitsPerSample = pStream->codec->bits_per_coded_sample;
 	
@@ -1322,6 +1325,9 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
     stream->profile = pStream->codec->profile;
     stream->level   = pStream->codec->level;
     stream->realtime = m_pInput->IsRealtime();
+    stream->codec_name = avcodec_get_name(stream->codec);
+    if (stream->profile != FF_PROFILE_UNKNOWN)
+      stream->profile_name = av_get_profile_name(avcodec_find_decoder(pStream->codec->codec_id), stream->profile);
 
     stream->source = STREAM_SOURCE_DEMUX;
     stream->pPrivate = pStream;
@@ -1558,6 +1564,7 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
     }
 #endif
 
+    strName = avcodec_get_name(stream->codec);
     AVCodec *codec = avcodec_find_decoder(stream->codec);
     if (codec)
       strName = codec->name;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1524,50 +1524,14 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
   std::string strName;
   if (stream)
   {
-    unsigned int in = stream->codec_fourcc;
-    // FourCC codes are only valid on video streams, audio codecs in AVI/WAV
-    // are 2 bytes and audio codecs in transport streams have subtle variation
-    // e.g AC-3 instead of ac3
-    if (stream->type == STREAM_VIDEO && in != 0)
-    {
-      char fourcc[5];
-#if defined(__powerpc__)
-      fourcc[0] = in & 0xff;
-      fourcc[1] = (in >> 8) & 0xff;
-      fourcc[2] = (in >> 16) & 0xff;
-      fourcc[3] = (in >> 24) & 0xff;
-#else
-      memcpy(fourcc, &in, 4);
-#endif
-      fourcc[4] = 0;
-      // fourccs have to be 4 characters
-      if (strlen(fourcc) == 4)
-      {
-        strName = fourcc;
-        StringUtils::ToLower(strName);
-        return strName;
-      }
-    }
-
-#ifdef FF_PROFILE_DTS_HD_MA
-    /* use profile to determine the DTS type */
     if (stream->codec == AV_CODEC_ID_DTS)
     {
-      if (stream->profile == FF_PROFILE_DTS_HD_MA)
-        strName = "dtshd_ma";
-      else if (stream->profile == FF_PROFILE_DTS_HD_HRA)
-        strName = "dtshd_hra";
-      else
-        strName = "dca";
-
-      return strName;
+      strName = stream->profile_name;
     }
-#endif
+    else
+      strName = stream->codec_name;
 
-    strName = avcodec_get_name(stream->codec);
-    AVCodec *codec = avcodec_find_decoder(stream->codec);
-    if (codec)
-      strName = codec->name;
+    StringUtils::ToLower(strName);
   }
   return strName;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -224,8 +224,8 @@ static bool PredicateAudioPriority(const SelectionStream& lh, const SelectionStr
   PREDICATE_RETURN(lh.channels
                  , rh.channels);
 
-  PREDICATE_RETURN(StreamUtils::GetCodecPriority(lh.codec)
-                 , StreamUtils::GetCodecPriority(rh.codec));
+  PREDICATE_RETURN(StreamUtils::GetCodecPriority(lh.codec_id, lh.codec_profile)
+                 , StreamUtils::GetCodecPriority(rh.codec_id, rh.codec_profile));
 
   PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
                  , rh.flags & CDemuxStream::FLAG_DEFAULT);
@@ -518,7 +518,9 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer, std::
       s.filename = demuxer->GetFileName();
       s.filename2 = filename2;
       s.name = stream->GetStreamName();
-      s.codec    = demuxer->GetStreamCodecName(stream->iId);
+      s.codec_name    = demuxer->GetStreamCodecName(stream->iId);
+      s.codec_id = stream->codec;
+      s.codec_profile = stream->profile;
       s.channels = 0; // Default to 0. Overwrite if STREAM_AUDIO below.
       if(stream->type == STREAM_VIDEO)
       {
@@ -4484,7 +4486,7 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info
   info.height = s.height;
   info.SrcRect = s.SrcRect;
   info.DestRect = s.DestRect;
-  info.videoCodecName = s.codec;
+  info.videoCodecName = s.codec_name;
   info.videoAspectRatio = s.aspect_ratio;
   info.stereoMode = s.stereo_mode;
 }
@@ -4518,7 +4520,7 @@ void CVideoPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 
   info.bitrate = s.bitrate;
   info.channels = s.channels;
-  info.audioCodecName = s.codec;
+  info.audioCodecName = s.codec_name;
 }
 
 int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string& subfilename)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -178,7 +178,9 @@ typedef struct SelectionStream
   CDemuxStream::EFlags flags = CDemuxStream::FLAG_NONE;
   int          source = 0;
   int          id = 0;
-  std::string  codec;
+  AVCodecID    codec_id = AV_CODEC_ID_NONE;
+  int          codec_profile = FF_PROFILE_UNKNOWN;
+  std::string  codec_name;
   int          channels = 0;
   int          bitrate = 0;
   int          width = 0;

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -128,7 +128,7 @@ bool CStreamDetailAudio::IsWorseThan(CStreamDetail *that)
     return false;
 
   // In case of a tie, revert to codec priority
-  return StreamUtils::GetCodecPriority(sda->m_strCodec) > StreamUtils::GetCodecPriority(m_strCodec);
+  return StreamUtils::GetCodecPriority(sda->m_codec_id, sda->m_codec_profile) > StreamUtils::GetCodecPriority(m_codec_id, m_codec_profile);
 }
 
 CStreamDetailSubtitle::CStreamDetailSubtitle() :

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -24,6 +24,10 @@
 #include <string>
 #include <vector>
 
+extern "C" {
+#include "libavcodec/avcodec.h"
+}
+
 class CStreamDetails;
 class CVariant;
 
@@ -74,6 +78,8 @@ public:
   virtual bool IsWorseThan(CStreamDetail *that);
 
   int m_iChannels;
+  AVCodecID   m_codec_id = AV_CODEC_ID_NONE;
+  int         m_codec_profile = FF_PROFILE_UNKNOWN;
   std::string m_strCodec;
   std::string m_strLanguage;
 };

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -20,25 +20,29 @@
 
 #include "StreamUtils.h"
 
-int StreamUtils::GetCodecPriority(const std::string &codec)
+int StreamUtils::GetCodecPriority(AVCodecID codecId, int codecProfile)
 {
   /*
    * Technically flac, truehd, and dtshd_ma are equivalently good as they're all lossless. However,
    * ffmpeg can't decode dtshd_ma losslessy yet.
    */
-  if (codec == "flac") // Lossless FLAC
+  if (codecId == AV_CODEC_ID_FLAC) // Lossless FLAC
     return 7;
-  if (codec == "truehd") // Dolby TrueHD
+  if (codecId == AV_CODEC_ID_TRUEHD) // Dolby TrueHD
     return 6;
-  if (codec == "dtshd_ma") // DTS-HD Master Audio (previously known as DTS++)
-    return 5;
-  if (codec == "dtshd_hra") // DTS-HD High Resolution Audio
-    return 4;
-  if (codec == "eac3") // Dolby Digital Plus
-    return 3;
-  if (codec == "dca") // DTS
+  if (codecId == AV_CODEC_ID_DTS)
+  {
+    if (codecProfile == FF_PROFILE_DTS_HD_MA)  // DTS-HD Master Audio (previously known as DTS++)
+      return 5;
+    if (codecProfile == FF_PROFILE_DTS_HD_HRA) // DTS-HD High Resolution Audio
+      return 4;
+    
     return 2;
-  if (codec == "ac3") // Dolby Digital
+  }
+  if (codecId == AV_CODEC_ID_EAC3) // Dolby Digital Plus
+    return 3;
+  if (codecId == AV_CODEC_ID_AC3) // Dolby Digital
     return 1;
+
   return 0;
 }

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -21,8 +21,12 @@
 
 #include <string>
 
+extern "C" {
+#include "libavcodec/avcodec.h"
+}
+
 class StreamUtils
 {
 public:
-  static int GetCodecPriority(const std::string &codec);
+  static int GetCodecPriority(AVCodecID codecId, int codecProfile);
 };

--- a/xbmc/utils/test/TestStreamUtils.cpp
+++ b/xbmc/utils/test/TestStreamUtils.cpp
@@ -24,12 +24,12 @@
 
 TEST(TestStreamUtils, General)
 {
-  EXPECT_EQ(0, StreamUtils::GetCodecPriority(""));
-  EXPECT_EQ(1, StreamUtils::GetCodecPriority("ac3"));
-  EXPECT_EQ(2, StreamUtils::GetCodecPriority("dca"));
-  EXPECT_EQ(3, StreamUtils::GetCodecPriority("eac3"));
-  EXPECT_EQ(4, StreamUtils::GetCodecPriority("dtshd_hra"));
-  EXPECT_EQ(5, StreamUtils::GetCodecPriority("dtshd_ma"));
-  EXPECT_EQ(6, StreamUtils::GetCodecPriority("truehd"));
-  EXPECT_EQ(7, StreamUtils::GetCodecPriority("flac"));
+  EXPECT_EQ(0, StreamUtils::GetCodecPriority(AV_CODEC_ID_NONE, FF_PROFILE_UNKNOWN));
+  EXPECT_EQ(1, StreamUtils::GetCodecPriority(AV_CODEC_ID_AC3, FF_PROFILE_UNKNOWN));
+  EXPECT_EQ(2, StreamUtils::GetCodecPriority(AV_CODEC_ID_DTS, FF_PROFILE_UNKNOWN));
+  EXPECT_EQ(3, StreamUtils::GetCodecPriority(AV_CODEC_ID_EAC3, FF_PROFILE_UNKNOWN));
+  EXPECT_EQ(4, StreamUtils::GetCodecPriority(AV_CODEC_ID_DTS, FF_PROFILE_DTS_HD_HRA));
+  EXPECT_EQ(5, StreamUtils::GetCodecPriority(AV_CODEC_ID_DTS, FF_PROFILE_DTS_HD_MA));
+  EXPECT_EQ(6, StreamUtils::GetCodecPriority(AV_CODEC_ID_TRUEHD, FF_PROFILE_UNKNOWN));
+  EXPECT_EQ(7, StreamUtils::GetCodecPriority(AV_CODEC_ID_FLAC, FF_PROFILE_UNKNOWN));
 }


### PR DESCRIPTION
@FernetMenta Ausnahmsweise auf Deutsch. Eigentlich wollte ich nur die label für Tonspuren auf dvds im osd anzeigbar machen. Dann ist mir aufgefallen, dass alle codec (Namen) von uns selbst mit festen strings belegt werden, das gefällt mir nicht. Deshalb dachte ich man könnte die ffmpeg Namen und IDs nehmen. Das zieht aber einen wahnsinnigen Rattenschwan nach sich, z.b. werden dann für DTS-HD MA keine label mehr angezeigt, weil irgendwo (k.a. wo) ein Vergleich fehlschlägt. Außerdem sind die Namen auch noch in der db gespeichert und werden über Umwege in die StreamDetails geladen, etc.
Bin mir sicher, dass es auf Anhieb zu Regressionen kommen würde.

Nachdem ich noch so viele andere Feature im Kopf habe und es zeitlich eh eng ist, ist meine Frage an Dich, ob es Deiner Meinung nach überhaupt Sinn macht in dieser Richtung weiter zu arbeiten. 
